### PR TITLE
Update deployment workflow to use GITHUB_TOKEN for API authentication

### DIFF
--- a/.github/workflows/deploy-api.production.main.yml
+++ b/.github/workflows/deploy-api.production.main.yml
@@ -168,14 +168,14 @@ jobs:
         id: deploy
         run: |
           # Validate GitHub token secret before deployment
-          if [ -z "${{ secrets.API_GITHUB_TOKEN }}" ]; then
-            echo "❌ ERROR: API_GITHUB_TOKEN secret is not set!"
-            echo "🔍 Please ensure the API_GITHUB_TOKEN secret is configured in repository settings"
+          if [ -z "${{ secrets.GITHUB_TOKEN }}" ]; then
+            echo "❌ ERROR: GITHUB_TOKEN secret is not set!"
+            echo "🔍 Please ensure the GITHUB_TOKEN secret is configured in repository settings"
             exit 1
           fi
           
           # Log token presence (first 4 characters for debugging)
-          GITHUB_TOKEN_VALUE="${{ secrets.API_GITHUB_TOKEN }}"
+          GITHUB_TOKEN_VALUE="${{ secrets.GITHUB_TOKEN }}"
           TOKEN_PREFIX=$(echo "$GITHUB_TOKEN_VALUE" | cut -c1-4)
           TOKEN_LENGTH=${#GITHUB_TOKEN_VALUE}
           echo "🔑 GitHub Token Debug: prefix='$TOKEN_PREFIX' length=$TOKEN_LENGTH"


### PR DESCRIPTION
- Change the reference from API_GITHUB_TOKEN to GITHUB_TOKEN in the deployment workflow, ensuring correct token usage for GitHub actions and improving deployment validation.