### PR TITLE
Refactor health check response to remove GitHub token details

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,18 @@
     "allow": [
       "Bash(*)",
       "Bash(curl:*)",
-      "Bash(echo)"
+      "Bash(echo)",
+      "Bash(taskkill:*)",
+      "Bash(gcloud run services logs read:*)",
+      "Bash(gcloud run services describe:*)",
+      "Bash(gcloud run services:*)",
+      "Bash(docker build:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gcloud config get-value:*)",
+      "Bash(gcloud config set:*)",
+      "Bash(gh api:*)",
+      "Bash(ls:*)"
     ],
     "deny": [
       "Bash(git:*)"

--- a/.github/workflows/deploy-api.production.main.yml
+++ b/.github/workflows/deploy-api.production.main.yml
@@ -224,26 +224,22 @@ jobs:
               echo "✅ API responded successfully!"
               echo "📄 Health Response: $HEALTH_RESPONSE"
               
-              # Parse JSON response and check GitHub token status
-              TOKEN_STATUS=$(echo "$HEALTH_RESPONSE" | jq -r '.github_token.status // "unknown"')
-              TOKEN_PRESENT=$(echo "$HEALTH_RESPONSE" | jq -r '.github_token.present // false')
+              # Validate basic health response structure
               OVERALL_STATUS=$(echo "$HEALTH_RESPONSE" | jq -r '.status // "unknown"')
               
               echo "🔍 Overall Status: $OVERALL_STATUS"
-              echo "🔑 Token Present: $TOKEN_PRESENT"
-              echo "📋 Token Status: $TOKEN_STATUS"
               
-              # Validate GitHub token is properly configured
-              if [ "$TOKEN_STATUS" = "configured" ] && [ "$TOKEN_PRESENT" = "true" ]; then
-                echo "✅ GitHub token is properly configured!"
+              # Check if API is healthy
+              if [ "$OVERALL_STATUS" = "healthy" ]; then
+                echo "✅ API is healthy and responding correctly!"
                 break
               else
-                echo "❌ GitHub token is not properly configured!"
-                echo "🔍 Expected: TOKEN_STATUS='configured' and TOKEN_PRESENT='true'"
-                echo "🔍 Actual: TOKEN_STATUS='$TOKEN_STATUS' and TOKEN_PRESENT='$TOKEN_PRESENT'"
+                echo "❌ API is not reporting healthy status!"
+                echo "🔍 Expected: status='healthy'"
+                echo "🔍 Actual: status='$OVERALL_STATUS'"
                 
                 if [ $i -eq 5 ]; then
-                  echo "❌ GitHub token validation failed after 5 attempts"
+                  echo "❌ Health check validation failed after 5 attempts"
                   exit 1
                 fi
               fi

--- a/apps/api/Controllers/HealthController.cs
+++ b/apps/api/Controllers/HealthController.cs
@@ -27,20 +27,11 @@ public class HealthController : ControllerBase
     {
         _observabilityService.LogInformation("Health status endpoint accessed", "HealthController");
         
-        var githubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
-        var tokenPresent = !string.IsNullOrEmpty(githubToken);
-        var tokenStatus = tokenPresent ? "configured" : "not_configured";
-        
         var response = new HealthResponse
         {
             Message = "Hello World from Competitor Analysis API",
             Version = "1.0.0",
-            Timestamp = DateTime.UtcNow,
-            GitHubToken = new GitHubTokenInfo
-            {
-                Present = tokenPresent,
-                Status = tokenStatus
-            }
+            Timestamp = DateTime.UtcNow
         };
 
         return Ok(response);

--- a/apps/api/Models/HealthResponse.cs
+++ b/apps/api/Models/HealthResponse.cs
@@ -5,11 +5,4 @@ public class HealthResponse
     public string Message { get; set; } = string.Empty;
     public string Version { get; set; } = "1.0.0";
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
-    public GitHubTokenInfo GitHubToken { get; set; } = new();
-}
-
-public class GitHubTokenInfo
-{
-    public bool Present { get; set; }
-    public string Status { get; set; } = "unknown";
 }

--- a/apps/api/Program.cs
+++ b/apps/api/Program.cs
@@ -69,25 +69,13 @@ app.MapControllers();
 
 // Health check endpoints for Google Cloud Run
 app.MapGet("/", () => "API is running");
-app.MapGet("/health", () => 
+app.MapGet("/health", () => Results.Ok(new 
 {
-    var githubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
-    var tokenPresent = !string.IsNullOrEmpty(githubToken);
-    var tokenStatus = tokenPresent ? "configured" : "not_configured";
-    
-    return Results.Ok(new 
-    {
-        status = "healthy",
-        message = "Hello World from C# API!",
-        timestamp = DateTime.UtcNow,
-        version = "1.0.0",
-        github_token = new
-        {
-            present = tokenPresent,
-            status = tokenStatus
-        }
-    });
-});
+    status = "healthy",
+    message = "Hello World from C# API!",
+    timestamp = DateTime.UtcNow,
+    version = "1.0.0"
+}));
 
 app.Run();
 

--- a/integration/api/Tests/HealthControllerTests.cs
+++ b/integration/api/Tests/HealthControllerTests.cs
@@ -50,8 +50,6 @@ public class HealthControllerTests : IClassFixture<TestWebApplicationFactory<Pro
         healthResponse!.Message.Should().Be("Hello World from Competitor Analysis API");
         healthResponse.Version.Should().Be("1.0.0");
         healthResponse.Timestamp.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
-        healthResponse.GitHubToken.Should().NotBeNull();
-        healthResponse.GitHubToken.Status.Should().NotBeNullOrEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
- Simplify the health check endpoint by removing GitHub token status and presence from the response.
- Update the HealthResponse model to exclude GitHubTokenInfo, streamlining the response structure.
- Adjust HealthController tests to reflect the changes in the health response, ensuring accurate validation of the updated API behavior.