### PR TITLE
Update integration workflow to target web directory for tests and dependencies

### DIFF
--- a/.github/workflows/test-integration.production.main.yml
+++ b/.github/workflows/test-integration.production.main.yml
@@ -98,11 +98,11 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: integration/package-lock.json
+          cache-dependency-path: integration/web/package-lock.json
       
       - name: 📥 Install Integration Dependencies
         run: |
-          cd integration
+          cd integration/web
           npm ci
       
       - name: 🔧 Build Observability Package
@@ -114,8 +114,8 @@ jobs:
       - name: 🧪 Run Integration Tests
         run: |
           echo "🚀 Running main production integration tests..."
-          cd integration
-          npm run test:main
+          cd integration/web
+          npm run test
         env:
           WEB_URL: ${{ inputs.web_url }}
           API_URL: ${{ inputs.api_url }}


### PR DESCRIPTION
- Adjust the integration workflow to change the directory to 'integration/web' for installing dependencies and running tests, ensuring the correct path is utilized for the integration process.
- Update the cache-dependency-path to reflect the new directory structure, improving the efficiency of the workflow.